### PR TITLE
fixed TriangulatedMesh

### DIFF
--- a/Procedural shape generation/Assets/PSG/Scripts/Mesh scripts/TriangulatedMesh.cs
+++ b/Procedural shape generation/Assets/PSG/Scripts/Mesh scripts/TriangulatedMesh.cs
@@ -98,7 +98,7 @@ namespace PSG
 
         protected override void BuildMeshComponents()
         {
-            Vector2 center = MeshHelper.GetCenter(Vertices);
+            Vector2 center = MeshHelper.GetCenter(Points);
             Vertices = new Vector3[Points.Length];
             for (int i = 0; i < Vertices.Length; i++)
             {


### PR DESCRIPTION
The generation of TriangulatedMesh is broken for now. 

It shows the following error when building mesh. 
"Vector2::GetCenter: vec cannot be null." 